### PR TITLE
Only scroll up if isRefresh is changed

### DIFF
--- a/lib/animatedPull.android.js
+++ b/lib/animatedPull.android.js
@@ -89,10 +89,12 @@ class AnimatedPTR extends React.Component {
   }
 
   componentWillReceiveProps(props) {
-    if(!props.isRefreshing) {
-      Animated.spring(this.state.refreshHeight, {
-        toValue: 0
-      }).start();
+      if(this.props.isRefreshing !== props.isRefreshing) {
+        if(!props.isRefreshing) {
+          Animated.spring(this.state.refreshHeight, {
+            toValue: 0
+          }).start();
+        }
     }
   }
   componentDidMount() {

--- a/lib/animatedPull.ios.js
+++ b/lib/animatedPull.ios.js
@@ -84,9 +84,11 @@ class AnimatedPTR extends React.Component {
   }
 
   componentWillReceiveProps(props) {
-    if(!props.isRefreshing) {
-      this.refs.PTR_ScrollComponent.scrollTo({y: 0});
-      this.setState({isScrollFree: true});
+    if(this.props.isRefreshing !== props.isRefreshing) {
+        if(!props.isRefreshing) {
+          this.refs.PTR_ScrollComponent.scrollTo({y: 0});
+          this.setState({isScrollFree: true});
+        }
     }
   }
 


### PR DESCRIPTION
I found out this issue that if user started to scroll up immediately after launching the app, the app will scroll up to the top and creates a bad user experience. This checks for the next props and only scroll if `isRefreshing` is updated
