### PR TITLE
OnScroll Event as prop

### DIFF
--- a/lib/animatedPull.android.js
+++ b/lib/animatedPull.android.js
@@ -53,7 +53,12 @@ class AnimatedPTR extends React.Component {
      * The pull to refresh background color.
      * @type {string}
      */
-    PTRbackgroundColor: React.PropTypes.string
+    PTRbackgroundColor: React.PropTypes.string,
+    /**
+     * Custom onScroll event
+     * @type {Function}
+     */
+     onScroll: React.PropTypes.func
   }
 
   static defaultProps = {
@@ -151,9 +156,13 @@ class AnimatedPTR extends React.Component {
   }
 
   render() {
-    let onScrollEvent = Animated.event([{
-      nativeEvent: { contentOffset: { y: this.state.scrollY }}
-    }]);
+    const onScroll = this.props.onScroll
+    let onScrollEvent = (event) => {
+      if (onScroll) {
+        onScroll(event)
+      }
+      this.state.scrollY.setValue(event.nativeEvent.contentOffset.y)
+    };
     let animateHeight = this.state.refreshHeight.interpolate({
       inputRange: [-120, 0],
       outputRange: [120, 0]

--- a/lib/animatedPull.ios.js
+++ b/lib/animatedPull.ios.js
@@ -48,7 +48,12 @@ class AnimatedPTR extends React.Component {
      * The pull to refresh background color.
      * @type {string}
      */
-    PTRbackgroundColor: React.PropTypes.string
+    PTRbackgroundColor: React.PropTypes.string,
+    /**
+     * Custom onScroll event
+     * @type {Function}
+     */
+     onScroll: React.PropTypes.func
   }
 
   static defaultProps = {
@@ -93,9 +98,13 @@ class AnimatedPTR extends React.Component {
   }
 
   render() {
-    let onScrollEvent = Animated.event([{
-      nativeEvent: { contentOffset: { y: this.state.scrollY }}
-    }]);
+    const onScroll = this.props.onScroll
+    let onScrollEvent = (event) => {
+      if (onScroll) {
+        onScroll(event)
+      }
+      this.state.scrollY.setValue(event.nativeEvent.contentOffset.y)
+    };
     let animateHeight = this.state.scrollY.interpolate({
       inputRange: [-this.props.minPullDistance,0],
       outputRange: [this.props.minPullDistance, 0]


### PR DESCRIPTION
As well as the normal onScroll behavior I added a prop to pass in an onScroll event callback. This is useful if the component containing the ptr needs to be aware of scroll events.