### PR TITLE
fix: React.PropTypes is discarded API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules/
+dist/
+npm-debug.log
+*.log
+.cache

--- a/animations/FadeAnimation.js
+++ b/animations/FadeAnimation.js
@@ -5,6 +5,7 @@ import {
   Image,
   UIManager
 } from 'react-native'
+import PropTypes from 'prop-types';
 
 export default class FadeAnimation extends React.Component {
   constructor(props) {
@@ -22,37 +23,37 @@ export default class FadeAnimation extends React.Component {
      * Component Type being created.  View allows for more nested components.
      * @type {Enum}
      */
-    componentType: React.PropTypes.oneOf(['View', 'Image']).isRequired,
+    componentType: PropTypes.oneOf(['View', 'Image']).isRequired,
 
     /**
      * If using image, define the source
      * @type {node}
      */
-    imageSrc: React.PropTypes.node,
+    imageSrc: PropTypes.node,
 
     /**
      * The components style props.
      * @type {StyleSheet}
      */
-    styleProps: React.PropTypes.any,
+    styleProps: PropTypes.any,
 
     /**
      * Fade Type for component.
      * @type {Enum}
      */
-    fadeType: React.PropTypes.oneOf(['FADE_IN', 'FADE_OUT']).isRequired,
+    fadeType: PropTypes.oneOf(['FADE_IN', 'FADE_OUT']).isRequired,
 
     /**
      * Lower bound opacity
      * @type {Integer}
      */
-    maxOpacity: React.PropTypes.number.isRequired,
-    
+    maxOpacity: PropTypes.number.isRequired,
+
     /**
      * Upper bound opacity
      * @type {Integer}
      */
-    minOpacity: React.PropTypes.number.isRequired
+    minOpacity: PropTypes.number.isRequired
   }
 
   render() {

--- a/animations/ScrollAnimation.js
+++ b/animations/ScrollAnimation.js
@@ -5,6 +5,7 @@ import {
   Image,
   UIManager
 } from 'react-native'
+import PropTypes from 'prop-types';
 
 export default class ScrollAnimation extends React.Component {
   constructor(props) {
@@ -30,34 +31,34 @@ export default class ScrollAnimation extends React.Component {
      * Sets when the animation should occur: before or during the refresh state.
      * @type {Enum}
      */
-    occurrence: React.PropTypes.oneOf(['BEFORE_REFRESH', 'DURING_REFRESH']).isRequired,
+    occurrence: PropTypes.oneOf(['BEFORE_REFRESH', 'DURING_REFRESH']).isRequired,
 
     /**
      * Component Type being created.  View allows for more nested components.
      * @type {Enum}
      */
-    componentType: React.PropTypes.oneOf(['View', 'Image']).isRequired,
+    componentType: PropTypes.oneOf(['View', 'Image']).isRequired,
 
     /**
      * If using image, define the source
      * @type {node}
      */
-    imageSrc: React.PropTypes.node,
+    imageSrc: PropTypes.node,
 
     /**
      * The components style props.
      * @type {StyleSheet}
      */
-    styleProps: React.PropTypes.any,
+    styleProps: PropTypes.any,
 
     /**
      * Points for where the animation components will start and end at on the X-axis.  If not moving on X axis,
      * only the from is required (or can be set the same)
      * @type {object}
      */
-    xValues: React.PropTypes.shape({
-      from: React.PropTypes.number.isRequired,
-      to: React.PropTypes.number,
+    xValues: PropTypes.shape({
+      from: PropTypes.number.isRequired,
+      to: PropTypes.number,
     }).isRequired,
 
     /**
@@ -65,16 +66,16 @@ export default class ScrollAnimation extends React.Component {
      * only the from is required (or can be set the same)
      * @type {object}
      */
-    yValues: React.PropTypes.shape({
-      from: React.PropTypes.number.isRequired,
-      to: React.PropTypes.number
+    yValues: PropTypes.shape({
+      from: PropTypes.number.isRequired,
+      to: PropTypes.number
     }).isRequired,
 
     /**
      * The targeted direction of where the animation should go.  Try to choose a suitable direction, or results might not match the intention.
      * @type {Enum}
      */
-    direction: React.PropTypes.oneOf([
+    direction: PropTypes.oneOf([
       'MOVE_DOWN', 'MOVE_UP', 'MOVE_LEFT', 'MOVE_RIGHT',
       'MOVE_UP_LEFT', 'MOVE_UP_RIGHT', 'MOVE_DOWN_LEFT', 'MOVE_DOWN_RIGHT'
     ]).isRequired,
@@ -83,27 +84,27 @@ export default class ScrollAnimation extends React.Component {
      * If set, allows for the animation to trigger at a specific Y-axis scroll number
      * @type {Integer}
      */
-    shouldTriggerAt: React.PropTypes.number,
+    shouldTriggerAt: PropTypes.number,
 
     /**
      * If set, will animate a moving animation to where values are set to.
      * @type {object}
      */
-    shouldHideDuringRefresh: React.PropTypes.shape({
-      toXValue: React.PropTypes.number,
-      toYValue: React.PropTypes.number,
+    shouldHideDuringRefresh: PropTypes.shape({
+      toXValue: PropTypes.number,
+      toYValue: PropTypes.number,
     }),
 
     /**
      * If set, will rotate an animation clockwise or counter-clockwise.  This will potentially be separated out into it's own animation.
      * @type {object}
      */
-    shouldRotate: React.PropTypes.shape({
-      direction: React.PropTypes.oneOf(['CLOCKWISE', 'COUNTER_CLOCKWISE']).isRequired,
-      rotationType: React.PropTypes.oneOf(['ROTATE_WITH_SCROLL', 'ROTATE_CONTINUOUSLY']).isRequired,
-      endRotationDeg: React.PropTypes.string.isRequired,
-      shouldRotateBack: React.PropTypes.bool,
-      rotationTiming: React.PropTypes.number.isRequired,
+    shouldRotate: PropTypes.shape({
+      direction: PropTypes.oneOf(['CLOCKWISE', 'COUNTER_CLOCKWISE']).isRequired,
+      rotationType: PropTypes.oneOf(['ROTATE_WITH_SCROLL', 'ROTATE_CONTINUOUSLY']).isRequired,
+      endRotationDeg: PropTypes.string.isRequired,
+      shouldRotateBack: PropTypes.bool,
+      rotationTiming: PropTypes.number.isRequired,
     })
   }
 

--- a/animations/TimedAnimation.js
+++ b/animations/TimedAnimation.js
@@ -5,6 +5,8 @@ import {
   Image,
   UIManager
 } from 'react-native'
+import PropTypes from 'prop-types';
+
 
 export default class TimedAnimation extends React.Component {
   constructor(props) {
@@ -26,23 +28,23 @@ export default class TimedAnimation extends React.Component {
      * Sets when the animation should occur: before or during the refresh state.
      * @type {Enum}
      */
-    occurrence: React.PropTypes.oneOf(['BEFORE_REFRESH', 'DURING_REFRESH']).isRequired,
+    occurrence: PropTypes.oneOf(['BEFORE_REFRESH', 'DURING_REFRESH']).isRequired,
 
     /**
      * Component Type being created.  View allows for more nested components.
      * @type {Enum}
      */
 
-    componentType: React.PropTypes.oneOf(['View', 'Image']).isRequired,
+    componentType: PropTypes.oneOf(['View', 'Image']).isRequired,
     /**
      * Points for where the animation components will start and end at on the X-axis.  If not moving on X axis,
      * only the from is required (or can be set the same)
      * @type {object}
      */
 
-    xValues: React.PropTypes.shape({
-      from: React.PropTypes.number.isRequired,
-      to: React.PropTypes.number,
+    xValues: PropTypes.shape({
+      from: PropTypes.number.isRequired,
+      to: PropTypes.number,
     }).isRequired,
 
     /**
@@ -50,34 +52,34 @@ export default class TimedAnimation extends React.Component {
      * only the from is required (or can be set the same)
      * @type {object}
      */
-    yValues: React.PropTypes.shape({
-      from: React.PropTypes.number.isRequired,
-      to: React.PropTypes.number
+    yValues: PropTypes.shape({
+      from: PropTypes.number.isRequired,
+      to: PropTypes.number
     }).isRequired,
 
     /**
      * The duration of how long the animation will take to complete in ms.
      * @type {Integer}
      */
-    duration: React.PropTypes.number.isRequired,
+    duration: PropTypes.number.isRequired,
 
     /**
      * Will repeat the animation after completion if set to true.
      * @type {[type]}
      */
-    shouldRepeat: React.PropTypes.bool,
+    shouldRepeat: PropTypes.bool,
 
     /**
      * The components style props.
      * @type {StyleSheet}
      */
-    styleProps: React.PropTypes.any,
+    styleProps: PropTypes.any,
 
     /**
      * If using image, define the source
      * @type {node}
      */
-    imageSrc: React.PropTypes.node,
+    imageSrc: PropTypes.node,
   }
 
   componentDidMount() {

--- a/lib/animatedPull.android.js
+++ b/lib/animatedPull.android.js
@@ -9,6 +9,7 @@ import {
 import TimedAnimation from '../animations/TimedAnimation';
 import ScrollAnimation from '../animations/ScrollAnimation';
 import FadeAnimation from '../animations/FadeAnimation';
+import PropTypes from 'prop-types';
 
 class AnimatedPTR extends React.Component {
   constructor(props) {
@@ -28,37 +29,37 @@ class AnimatedPTR extends React.Component {
      * Refresh state set by parent to trigger refresh
      * @type {Boolean}
      */
-    isRefreshing : React.PropTypes.bool.isRequired,
+    isRefreshing : PropTypes.bool.isRequired,
     /**
      * Sets pull distance for how far the Y axis needs to be pulled before a refresh event is triggered
      * @type {Integer}
      */
-    minPullDistance : React.PropTypes.number,
+    minPullDistance : PropTypes.number,
     /**
      * Callback for when the refreshing state occurs
      * @type {Function}
      */
-    onRefresh : React.PropTypes.func.isRequired,
+    onRefresh : PropTypes.func.isRequired,
     /**
      * The content view which should be passed in as a scrollable type (i.e ScrollView or ListView)
      * @type {Object}
      */
-    contentComponent: React.PropTypes.object.isRequired,
+    contentComponent: PropTypes.object.isRequired,
     /**
      * The content view's background color, not to be mistaken with the content component's background color
      * @type {string}
      */
-    contentBackgroundColor: React.PropTypes.string,
+    contentBackgroundColor: PropTypes.string,
     /**
      * The pull to refresh background color.
      * @type {string}
      */
-    PTRbackgroundColor: React.PropTypes.string,
+    PTRbackgroundColor: PropTypes.string,
     /**
      * Custom onScroll event
      * @type {Function}
      */
-     onScroll: React.PropTypes.func
+     onScroll: PropTypes.func
   }
 
   static defaultProps = {

--- a/lib/animatedPull.ios.js
+++ b/lib/animatedPull.ios.js
@@ -7,6 +7,7 @@ import {
 import TimedAnimation from '../animations/TimedAnimation';
 import ScrollAnimation from '../animations/ScrollAnimation';
 import FadeAnimation from '../animations/FadeAnimation';
+import PropTypes from 'prop-types';
 
 class AnimatedPTR extends React.Component {
   constructor(props) {
@@ -23,37 +24,37 @@ class AnimatedPTR extends React.Component {
      * Refresh state set by parent to trigger refresh
      * @type {Boolean}
      */
-    isRefreshing : React.PropTypes.bool.isRequired,
+    isRefreshing : PropTypes.bool.isRequired,
     /**
      * Sets pull distance for how far the Y axis needs to be pulled before a refresh event is triggered
      * @type {Integer}
      */
-    minPullDistance : React.PropTypes.number,
+    minPullDistance : PropTypes.number,
     /**
      * Callback for when the refreshing state occurs
      * @type {Function}
      */
-    onRefresh : React.PropTypes.func.isRequired,
+    onRefresh : PropTypes.func.isRequired,
     /**
      * The content view which should be passed in as a scrollable type (i.e ScrollView or ListView)
      * @type {Object}
      */
-    contentComponent: React.PropTypes.object.isRequired,
+    contentComponent: PropTypes.object.isRequired,
     /**
      * The content view's background color, not to be mistaken with the content component's background color
      * @type {string}
      */
-    contentBackgroundColor: React.PropTypes.string,
+    contentBackgroundColor: PropTypes.string,
     /**
      * The pull to refresh background color.
      * @type {string}
      */
-    PTRbackgroundColor: React.PropTypes.string,
+    PTRbackgroundColor: PropTypes.string,
     /**
      * Custom onScroll event
      * @type {Function}
      */
-     onScroll: React.PropTypes.func
+     onScroll: PropTypes.func
   }
 
   static defaultProps = {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/evetstech/react-native-animated-ptr/issues"
   },
-  "homepage": "https://github.com/evetstech/react-native-animated-ptr#readme"
+  "homepage": "https://github.com/evetstech/react-native-animated-ptr#readme",
+  "dependencies": {
+    "prop-types": "^15.6.1"
+  }
 }


### PR DESCRIPTION
React.PropTypes has moved into a different package since React v15.5. Please use the prop-types library instead.